### PR TITLE
Fixes another event handler leak.

### DIFF
--- a/copy-to.js
+++ b/copy-to.js
@@ -15,7 +15,7 @@ var CopyStreamQuery = function(text) {
 
 util.inherits(CopyStreamQuery, Transform)
 
-var eventTypes = ['close', 'data', 'end']
+var eventTypes = ['close', 'data', 'end', 'error']
 
 CopyStreamQuery.prototype.submit = function(connection) {
   connection.query(this.text)

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -49,9 +49,10 @@ var testLeak = function(rounds) {
 
   async.timesSeries(rounds, runStream, function(err) {
     assert.equal(err, null)
+    assert.equal(fromClient.connection.stream.listeners('close').length, 0)
     assert.equal(fromClient.connection.stream.listeners('data').length, 1)
     assert.equal(fromClient.connection.stream.listeners('end').length, 2)
-    assert.equal(fromClient.connection.stream.listeners('close').length, 0)
+    assert.equal(fromClient.connection.stream.listeners('error').length, 1)
     fromClient.end()
   })
 }


### PR DESCRIPTION
It turns out 'error' handlers were leaking as well, although more slowly.
