### PR TITLE
Fixed readme example for COPY FROM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ var copyFrom = require('pg-copy-streams').from;
 pg.connect(function(err, client, done) {
   var stream = client.query(copyFrom('COPY my_table FROM STDIN'));
   var fileStream = fs.createReadStream('some_file.tdv')
-  fileStream.pipe(stream);
-  fileStream.on('end', done);
-  fileStream.on('error', done);
+  fileStream.pipe(stream).on('end', done).on('error', done);
 });
 ```
 


### PR DESCRIPTION
The example would call the `done` function when the FileStream had finished rather than the stream to postgres had finished. This caused a test of mine to fail where after end checking the database had the correct row count, and the fix was to put the `on('end'` callback on the returned (piped) stream.

My code is here, https://github.com/grahamjenson/ger/blob/master/lib/psql_esm.coffee#L182

Cheers, Great project!
