### PR TITLE
Fixes pipe from a file to table example in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ var copyFrom = require('pg-copy-streams').from;
 pg.connect(function(err, client, done) {
   var stream = client.query(copyFrom('COPY my_table FROM STDIN'));
   var fileStream = fs.createReadStream('some_file.tdv')
-  fileStream.pipe(stream);
-  fileStream.on('end', done);
   fileStream.on('error', done);
+  fileStream.pipe(stream).on('finish', done).on('error', done);
 });
 ```
 
@@ -53,11 +52,11 @@ $ npm install pg-copy-streams
 
 ## notice
 
-This module __only__ works with the pure JavaScript bindings.  If you're using `require('pg').native` please make sure to use normal `require('pg')` or `require('pg.js')` when you're using copy streams. 
+This module __only__ works with the pure JavaScript bindings.  If you're using `require('pg').native` please make sure to use normal `require('pg')` or `require('pg.js')` when you're using copy streams.
 
 Before you set out on this magical piping journey, you _really_ should read this: http://www.postgresql.org/docs/9.3/static/sql-copy.html, and you might want to take a look at the [tests](https://github.com/brianc/node-pg-copy-streams/tree/master/test) to get an idea of how things work.
 
-## contributing 
+## contributing
 
 Instead of adding a bunch more code to the already bloated [node-postgres](https://github.com/brianc/node-postgres) I am trying to make the internals extensible and work on adding edge-case features as 3rd party modules.
 This is one of those.


### PR DESCRIPTION
Save hooks also cleaned up trailing spaces.
