### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ var copyFrom = require('pg-copy-streams').from;
 pg.connect(function(err, client, done) {
   var stream = client.query(copyFrom('COPY my_table FROM STDIN'));
   var fileStream = fs.createReadStream('some_file.tdv')
+  
+  fileStream.pipe(stream);
+  fileStream.on('end', done)
   fileStream.on('error', done);
-  fileStream.pipe(stream).on('finish', done).on('error', done);
 });
 ```
 


### PR DESCRIPTION
I spend hours trying to fix a error not popping up in a promise reduce chain, only to find out that the example I used has the 'finish' event instead of the correct 'end' event :) 

This commit will fix that and make the example-layout more consistent with the table->stdout example.