### PR TITLE
Expose row count after COPY FROM command

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
   lenBuffer.writeUInt32BE(chunk.length + 4, 0)
   this.push(lenBuffer)
   this.push(chunk)
-  this.rowCount++
   cb()
 }
 
@@ -58,7 +57,14 @@ CopyStreamQuery.prototype.handleCopyInResponse = function(connection) {
   this.pipe(connection.stream)
 }
 
-CopyStreamQuery.prototype.handleCommandComplete = function() {
+CopyStreamQuery.prototype.handleCommandComplete = function(msg) {
+  // Parse affected row count as in
+  // https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L37
+  var match = /COPY (\d+)/.exec((msg || {}).text)
+  if (match[1]) {
+    this.rowCount = parseInt(match[1], 10)
+  }
+
   this.unpipe()
   this.emit('end')
 }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ CopyStreamQuery.prototype.handleCommandComplete = function(msg) {
   // Parse affected row count as in
   // https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L37
   var match = /COPY (\d+)/.exec((msg || {}).text)
-  if (match[1]) {
+  if (match) {
     this.rowCount = parseInt(match[1], 10)
   }
 

--- a/test/copy-from.js
+++ b/test/copy-from.js
@@ -30,10 +30,6 @@ var testRange = function(top) {
 
   var txt = 'COPY numbers FROM STDIN'
   var stream = fromClient.query(copy(txt))
-  var rowEmitCount = 0
-  stream.on('row', function() {
-    rowEmitCount++
-  })
   for(var i = 0; i < top; i++) {
     stream.write(Buffer('' + i + '\t' + i*10 + '\n'))
   }


### PR DESCRIPTION
This addresses #36, exposing the row count as reported by the Postgres server.

If there is a better way to do this, e.g. if there's a way to tap into `Result.prototype.addCommandComplete` ([link](https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L23)) from the `pg` library, please advise and I will be happy to update.

I haven't had an opportunity to use `copy-to`, and I don't know if `rowCount` is working there or not, so I didn't attempt to modify it.