### PR TITLE
Use `end` stream option instead of not calling _flush callback

### DIFF
--- a/copy-to.js
+++ b/copy-to.js
@@ -4,6 +4,7 @@ module.exports = function(txt, options) {
 
 var Transform = require('stream').Transform
 var util = require('util')
+var code = require('./message-formats')
 
 var CopyStreamQuery = function(text, options) {
   Transform.call(this, options)
@@ -21,13 +22,6 @@ CopyStreamQuery.prototype.submit = function(connection) {
   this.connection = connection
   this.connection.removeAllListeners('copyData')
   connection.stream.pipe(this)
-}
-
-var code = {
-  E: 69, //Error
-  H: 72, //CopyOutResponse
-  d: 0x64, //CopyData
-  c: 0x63 //CopyDone
 }
 
 CopyStreamQuery.prototype._detach = function() {
@@ -50,7 +44,7 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
       return cb();
     }
     if(chunk[0] != code.H) {
-      this.emit('error', new Error('Expected copy out response'))
+      this.emit('error', new Error('Expected copyOutResponse code (H)'))
     }
     var length = chunk.readUInt32BE(1)
     offset = 1
@@ -66,7 +60,7 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
     }
     //something bad happened
     if(messageCode != code.d) {
-      return this.emit('error', new Error('expected "d" (copydata message)'))
+      return this.emit('error', new Error('Expected copyData code (d)'))
     }
     var length = chunk.readUInt32BE(offset + 1) - 4 //subtract length of UInt32
     //can we read the next row?

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
 
 var Transform = require('stream').Transform
 var util = require('util')
+var code = require('./message-formats')
 
 var CopyStreamQuery = function(text, options) {
   Transform.call(this, options)
@@ -26,11 +27,6 @@ CopyStreamQuery.prototype.submit = function(connection) {
   connection.query(this.text)
 }
 
-var code = {
-  H: 72, //CopyOutResponse
-  d: 0x64, //CopyData
-  c: 0x63 //CopyDone
-}
 
 var copyDataBuffer = Buffer([code.d])
 CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -45,8 +45,7 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
 CopyStreamQuery.prototype._flush = function(cb) {
   var finBuffer = Buffer([code.c, 0, 0, 0, 4])
   this.push(finBuffer)
-  //never call this callback, do not close underlying stream
-  //cb()
+  cb()
 }
 
 CopyStreamQuery.prototype.handleError = function(e) {
@@ -54,7 +53,7 @@ CopyStreamQuery.prototype.handleError = function(e) {
 }
 
 CopyStreamQuery.prototype.handleCopyInResponse = function(connection) {
-  this.pipe(connection.stream)
+  this.pipe(connection.stream, { end: false })
 }
 
 CopyStreamQuery.prototype.handleCommandComplete = function(msg) {

--- a/message-formats.js
+++ b/message-formats.js
@@ -1,0 +1,17 @@
+/**
+ * The COPY feature uses the following protocol codes.
+ * The codes for the most recent protocol version are documented on
+ * https://www.postgresql.org/docs/current/static/protocol-message-formats.html
+ * 
+ * The protocol flow itself is described on
+ * https://www.postgresql.org/docs/current/static/protocol-flow.html
+ */
+module.exports = {
+  E: 0x45, //Error
+  G: 0x47, //CopyInResponse
+  H: 0x48, //CopyOutResponse
+  W: 0x57, //CopyBothResponse
+  d: 0x64, //CopyData
+  c: 0x63, //CopyDone
+  f: 0x66  //CopyFail
+} 


### PR DESCRIPTION
This PR changes the way the pg connection is not closed upon COPY finish.
this seems cleaner.