### PR TITLE
Accept some PostgreSQL async messages (cf message format COPY protocol)

### DIFF
--- a/message-formats.js
+++ b/message-formats.js
@@ -7,11 +7,19 @@
  * https://www.postgresql.org/docs/current/static/protocol-flow.html
  */
 module.exports = {
-  ErrorResponse:    0x45,
-  CopyInResponse:   0x47,
-  CopyOutResponse:  0x48,
-  CopyBothResponse: 0x57,
-  CopyData:         0x64,
-  CopyDone:         0x63,
-  CopyFail:         0x66
+  ErrorResponse:        0x45, // E
+  CopyInResponse:       0x47, // G
+  CopyOutResponse:      0x48, // H
+  CopyBothResponse:     0x57, // W
+  CopyDone:             0x63, // c
+  CopyData:             0x64, // d
+  CopyFail:             0x66, // f
+
+  // It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages;
+  // frontends must handle these cases, and should be prepared for other asynchronous message types as well
+  // (see Section 50.2.6).
+  // Otherwise, any message type other than CopyData or CopyDone may be treated as terminating copy-out mode.
+  NotificationResponse: 0x41, // A
+  NoticeResponse:       0x4E, // N
+  ParameterStatus:      0x53  // S
 } 


### PR DESCRIPTION
The COPY protocol states that 

> It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages; frontends must handle these cases, and should be prepared for other asynchronous message types as well (see Section 50.2.6). Otherwise, any message type other than CopyData or CopyDone may be treated as terminating copy-out mode.

I did not write tests for those since I am not sure yet how to generate them.