### PR TITLE
Fix NoticeResponse test and handle other messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,16 +30,18 @@ CopyStreamQuery.prototype.submit = function(connection) {
 
 var copyDataBuffer = Buffer([code.CopyData])
 CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
+  var Int32Len = 4;
   this.push(copyDataBuffer)
-  var lenBuffer = Buffer(4)
-  lenBuffer.writeUInt32BE(chunk.length + 4, 0)
+  var lenBuffer = Buffer(Int32Len)
+  lenBuffer.writeUInt32BE(chunk.length + Int32Len, 0)
   this.push(lenBuffer)
   this.push(chunk)
   cb()
 }
 
 CopyStreamQuery.prototype._flush = function(cb) {
-  var finBuffer = Buffer([code.CopyDone, 0, 0, 0, 4])
+  var Int32Len = 4;
+  var finBuffer = Buffer([code.CopyDone, 0, 0, 0, Int32Len])
   this.push(finBuffer)
   cb()
 }

--- a/message-formats.js
+++ b/message-formats.js
@@ -7,11 +7,19 @@
  * https://www.postgresql.org/docs/current/static/protocol-flow.html
  */
 module.exports = {
-  ErrorResponse:    0x45,
-  CopyInResponse:   0x47,
-  CopyOutResponse:  0x48,
-  CopyBothResponse: 0x57,
-  CopyData:         0x64,
-  CopyDone:         0x63,
-  CopyFail:         0x66
+  ErrorResponse:        0x45, // E
+  CopyInResponse:       0x47, // G
+  CopyOutResponse:      0x48, // H
+  CopyBothResponse:     0x57, // W
+  CopyDone:             0x63, // c
+  CopyData:             0x64, // d
+  CopyFail:             0x66, // f
+
+  // It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages;
+  // frontends must handle these cases, and should be prepared for other asynchronous message types as well
+  // (see Section 50.2.6).
+  // Otherwise, any message type other than CopyData or CopyDone may be treated as terminating copy-out mode.
+  NotificationResponse: 0x41, // A
+  NoticeResponse:       0x4E, // N
+  ParameterStatus:      0x53  // S
 } 


### PR DESCRIPTION
This PR fixes the NoticeResponse bug #51 by rewriting the algorithm in order to accept specific messages

> It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages; frontends must handle these cases, and should be prepared for other asynchronous message types as well (see Section 50.2.6). Otherwise, any message type other than CopyData or CopyDone may be treated as terminating copy-out mode.