### PR TITLE
Improve performance of COPY TO

### DIFF
--- a/copy-to.js
+++ b/copy-to.js
@@ -44,12 +44,10 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
 
   var buffer = Buffer.alloc(chunk.length);
   var buffer_offset = 0;
-  var buffer_sent = false;
 
   this.pushBufferIfneeded = function() {
-    if(needPush && !buffer_sent && buffer_offset > 0) {
+    if (needPush && buffer_offset > 0) {
       this.push(buffer.slice(0, buffer_offset))
-      buffer_sent = true;
       buffer_offset = 0;
     }
   }


### PR DESCRIPTION
Under some circumstances, the COPY TO streamming can be CPU-bound,
particularly when PG holds the resultset in memory buffers, the network is fast, and the size
of the rows << chunk (64 KB in my linux box).

This commits improves the situation by creating a buffer of `chunk`
size and fitting in as many rows as it can before pushing them. This
results in more balanced read and writes (in terms of size and in bigger
chunks) as well as more frequent calls to the callback, thus freeing the
main loop for other events to be processed, and therefore avoiding
starvation.