### PR TITLE
new copy-to class to work with connection pool

### DIFF
--- a/copy-to2.js
+++ b/copy-to2.js
@@ -1,0 +1,131 @@
+module.exports = function(txt, options) {
+    return new CopyStreamQuery(txt, options)
+  }
+  
+  var Transform = require('stream').Transform
+  var util = require('util')
+  var code = require('./message-formats')
+  
+  var CopyStreamQuery = function(text, options) {
+    Transform.call(this, options)
+    this.text = text
+    this._gotCopyOutResponse = false
+    this.rowCount = 0
+  }
+  
+  util.inherits(CopyStreamQuery, Transform)
+  
+  var eventTypes = ['close', 'data', 'end', 'error']
+  
+  CopyStreamQuery.prototype.submit = function(connection) {
+    connection.query(this.text)
+    this.connection = connection
+    this.connection.removeAllListeners('copyData')
+    this.listeners = connection.stream.listeners('data');
+    connection.stream.removeAllListeners('data');
+    //connection.stream.pipe(this)
+    var self = this;
+    connection.stream.on('data', function(chunk) {
+      self._transform(chunk,'',function(){});
+    });
+  }
+  
+  CopyStreamQuery.prototype._detach = function() {
+    // this.connection.stream.unpipe(this)
+    this.connection.stream.removeAllListeners('data');
+    // Unpipe can drop us out of flowing mode
+    this.connection.stream.resume()
+    for(var i=0;i<this.listeners.length;i++){
+      this.connection.stream.addListener('data',this.listeners[i]);
+    }
+  }
+  
+  CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
+    var offset = 0
+    var Byte1Len = 1;
+    var Int32Len = 4;
+    if(this._remainder && chunk) {
+      chunk = Buffer.concat([this._remainder, chunk])
+    }
+  
+    var length;
+    var messageCode;
+    var needPush = false;
+  
+    while((chunk.length - offset) >= (Byte1Len + Int32Len)) {
+      var messageCode = chunk[offset]
+  
+      //console.log('PostgreSQL message ' + String.fromCharCode(messageCode))
+      switch(messageCode) {
+  
+        // detect COPY start
+        case code.CopyOutResponse:
+          if (!this._gotCopyOutResponse) {
+            this._gotCopyOutResponse = true
+          } else {
+            this.emit('error', new Error('Unexpected CopyOutResponse message (H)'))
+          }
+          break;
+  
+        // meaningful row
+        case code.CopyData:
+          needPush = true;
+          break;
+  
+        // standard interspersed messages. discard
+        case code.ParameterStatus:
+        case code.NoticeResponse:
+        case code.NotificationResponse:
+          break;
+    
+        case code.ErrorResponse:
+        case code.CopyDone:
+          this._detach()
+          if (offset+1 < chunk.length) {
+            this.connection.stream.emit('data', chunk.slice(offset));
+          }
+          this.push(null)
+          return cb();
+          break;
+        default:
+          this.emit('error', new Error('Unexpected PostgreSQL message ' + String.fromCharCode(messageCode)))
+      }
+  
+      length = chunk.readUInt32BE(offset+Byte1Len)
+      if(chunk.length >= (offset + Byte1Len + length)) {
+        offset += Byte1Len + Int32Len
+        if (needPush) {
+          var row = chunk.slice(offset, offset + length - Int32Len)
+          this.rowCount++
+          this.push(row)
+        }
+        offset += (length - Int32Len)
+      } else {
+        // we need more chunks for a complete message
+        break;
+      }
+    }
+  
+    if(chunk.length - offset) {
+      var slice = chunk.slice(offset)
+      this._remainder = slice
+    } else {
+      this._remainder = false
+    }
+    cb()
+  }
+  
+  CopyStreamQuery.prototype.handleError = function(e) {
+    this.emit('error', e)
+  }
+  
+  CopyStreamQuery.prototype.handleCopyData = function(chunk) {
+  }
+  
+  CopyStreamQuery.prototype.handleCommandComplete = function() {
+  this.push(null);
+  }
+  
+  CopyStreamQuery.prototype.handleReadyForQuery = function() {
+  }
+  

--- a/copy-to2.js
+++ b/copy-to2.js
@@ -1,130 +1,157 @@
 module.exports = function(txt, options) {
-    return new CopyStreamQuery(txt, options)
-  }
-  
-  var Readable = require('stream').Readable
-  var util = require('util')
-  var code = require('./message-formats')
-  
-  var CopyStreamQuery = function(text, options) {
-    Readable.call(this, options)
-    this.text = text
-    this._gotCopyOutResponse = false
-    this.rowCount = 0
-  }
-  
-  util.inherits(CopyStreamQuery, Readable)
-  
-  var eventTypes = ['close', 'data', 'end', 'error']
-  
-  CopyStreamQuery.prototype.submit = function(connection) {
-    connection.query(this.text)
-    this.connection = connection
-    this.connection.removeAllListeners('copyData')
-    this.listeners = connection.stream.listeners('data');
-    connection.stream.removeAllListeners('data');
-    var self = this;
-    connection.stream.on('data', function(chunk) {
+  return new CopyStreamQuery(txt, options)
+}
+
+var Readable = require('stream').Readable
+var util = require('util')
+var code = require('./message-formats')
+
+var CopyStreamQuery = function(text, options) {
+  Readable.call(this, options)
+  this.text = text
+  this._gotCopyOutResponse = false
+  this.rowCount = 0
+  this.Byte1Len = 1;
+  this.Int32Len = 4;
+
+}
+
+util.inherits(CopyStreamQuery, Readable)
+
+var eventTypes = ['close', 'data', 'end', 'error']
+
+CopyStreamQuery.prototype.submit = function(connection) {
+  connection.query(this.text)
+  this.connection = connection
+  this.connection.removeAllListeners('copyData')
+  // remove connection listener to avoid create full length buffer
+  this.listeners = connection.stream.listeners('data');
+  connection.stream.removeAllListeners('data');
+  // put our listener to process copy data
+  var self = this;
+  this._listener = function(chunk) {
       self._process(chunk);
-    });
+  };
+  connection.stream.on('data', this._listener);
+}
+
+CopyStreamQuery.prototype._detach = function() {
+  // remove my listener
+  this.connection.stream.removeListener('data',this._listener);
+  // resume stream
+  this.connection.stream.resume()
+  // push previous listeners
+  for(var i=0;i<this.listeners.length;i++){
+    this.connection.stream.addListener('data',this.listeners[i]);
   }
-  
-  CopyStreamQuery.prototype._detach = function() {
-    this.connection.stream.removeAllListeners('data');
-    // Unpipe can drop us out of flowing mode
-    this.connection.stream.resume()
-    for(var i=0;i<this.listeners.length;i++){
-      this.connection.stream.addListener('data',this.listeners[i]);
-    }
+}
+CopyStreamQuery.prototype._read = function() {
+}
+
+CopyStreamQuery.prototype._pushData = function(chunk, offset) {
+  // push data from copy command
+  var chunkLength = chunk.length - offset;
+  // process the rest of the chunk or bytes rest
+  var length = Math.min(this._copyBytesRest, chunkLength);
+  var buffer = chunk.slice(offset, offset + length);
+  this.push(buffer);
+  // substract bytes processed
+  this._copyBytesRest -= length;
+  if (this._copyBytesRest === 0){
+    // finish
+    this._copyisCopying = false;
   }
-  CopyStreamQuery.prototype._read = function() {
+  // return updated offset
+  return offset + length;
+}
+
+CopyStreamQuery.prototype._process = function(chunk) {
+  var offset = 0
+  if(this._remainder && chunk) {
+    chunk = Buffer.concat([this._remainder, chunk])
   }
 
-  CopyStreamQuery.prototype._process = function(chunk) {
-    var offset = 0
-    var Byte1Len = 1;
-    var Int32Len = 4;
-    if(this._remainder && chunk) {
-      chunk = Buffer.concat([this._remainder, chunk])
-    }
-  
-    var length;
-    var messageCode;
-    var needPush = false;
-  
-    while((chunk.length - offset) >= (Byte1Len + Int32Len)) {
-      var messageCode = chunk[offset]
-  
-      //console.log('PostgreSQL message ' + String.fromCharCode(messageCode))
-      switch(messageCode) {
-  
-        // detect COPY start
-        case code.CopyOutResponse:
-          if (!this._gotCopyOutResponse) {
-            this._gotCopyOutResponse = true
-          } else {
-            this.emit('error', new Error('Unexpected CopyOutResponse message (H)'))
-          }
-          break;
-  
-        // meaningful row
-        case code.CopyData:
-          needPush = true;
-          break;
-  
-        // standard interspersed messages. discard
-        case code.ParameterStatus:
-        case code.NoticeResponse:
-        case code.NotificationResponse:
-          break;
-    
-        case code.ErrorResponse:
-        case code.CopyDone:
-          this._detach()
-          if (offset+1 < chunk.length) {
-            this.connection.stream.emit('data', chunk.slice(offset));
-          }
-          this.push(null)
-          return;
-          break;
-        default:
-          this.emit('error', new Error('Unexpected PostgreSQL message ' + String.fromCharCode(messageCode)))
-      }
-  
-      length = chunk.readUInt32BE(offset+Byte1Len)
-      if(chunk.length >= (offset + Byte1Len + length)) {
-        offset += Byte1Len + Int32Len
-        if (needPush) {
-          var row = chunk.slice(offset, offset + length - Int32Len)
-          this.rowCount++
-          this.push(row)
+  var length;
+  var messageCode;
+  // if copying data
+  if (this._copyisCopying) {
+    offset = this._pushData(chunk, offset);
+    // if all chunk consumed return
+    if (offset === chunk.length) return;
+  }
+
+  while((chunk.length - offset) >= (this.Byte1Len + this.Int32Len)) {
+    var messageCode = chunk[offset]
+
+    //console.log('PostgreSQL message ' + String.fromCharCode(messageCode))
+    switch(messageCode) {
+
+      // detect COPY start
+      case code.CopyOutResponse:
+        if (!this._gotCopyOutResponse) {
+          this._gotCopyOutResponse = true
+        } else {
+          this.emit('error', new Error('Unexpected CopyOutResponse message (H)'))
         }
-        offset += (length - Int32Len)
-      } else {
-        // we need more chunks for a complete message
         break;
-      }
-    }
+
+      // meaningful row
+      case code.CopyData:
+        // signal start copy data and process this chunk
+        this._copyisCopying = true;
+        this._copyTotalLength = chunk.readUInt32BE(offset+this.Byte1Len) - this.Int32Len;
+        this._copyBytesRest = this._copyTotalLength;
+        offset = this._pushData(chunk, offset + this.Byte1Len + this.Int32Len);
+        continue;
+        break;
+
+      // standard interspersed messages. discard
+      case code.ParameterStatus:
+      case code.NoticeResponse:
+      case code.NotificationResponse:
+        break;
   
-    if(chunk.length - offset) {
-      var slice = chunk.slice(offset)
-      this._remainder = slice
+      case code.ErrorResponse:
+      case code.CopyDone:
+        this._detach()
+        if (offset+1 < chunk.length) {
+          this.connection.stream.emit('data', chunk.slice(offset));
+        }
+        this.push(null)
+        return;
+        break;
+      default:
+        this.emit('error', new Error('Unexpected PostgreSQL message ' + String.fromCharCode(messageCode)))
+    }
+
+    length = chunk.readUInt32BE(offset+this.Byte1Len)
+    if(chunk.length >= (offset + this.Byte1Len + length)) {
+      offset += this.Byte1Len + this.Int32Len
+      offset += (length - this.Int32Len)
     } else {
-      this._remainder = false
+      // we need more chunks for a complete message
+      break;
     }
   }
-  
-  CopyStreamQuery.prototype.handleError = function(e) {
-    this.emit('error', e)
+
+  if(chunk.length - offset) {
+    var slice = chunk.slice(offset)
+    this._remainder = slice
+  } else {
+    this._remainder = false
   }
-  
-  CopyStreamQuery.prototype.handleCopyData = function(chunk) {
-  }
-  
-  CopyStreamQuery.prototype.handleCommandComplete = function() {
-  
-  }
-  
-  CopyStreamQuery.prototype.handleReadyForQuery = function() {
-  }
-  
+}
+
+CopyStreamQuery.prototype.handleError = function(e) {
+  this.emit('error', e)
+}
+
+CopyStreamQuery.prototype.handleCopyData = function(chunk) {
+}
+
+CopyStreamQuery.prototype.handleCommandComplete = function() {
+
+}
+
+CopyStreamQuery.prototype.handleReadyForQuery = function() {
+}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 var CopyToQueryStream = require('./copy-to')
+var CopyToQueryStream2 = require('./copy-to2')
 module.exports = {
   to: function(txt, options) {
     return new CopyToQueryStream(txt, options)
   },
   from: function (txt, options) {
     return new CopyStreamQuery(txt, options)
+  },
+  to2: function(txt, options) {
+    return new CopyToQueryStream2(txt, options)
   }
 }
 


### PR DESCRIPTION
copy-to does not work when reusing connection from pool. After pipe stream I loose internal connection status and any command I send after unpipe does not work.