### PR TITLE
Destroy stream after last row

### DIFF
--- a/copy-to.js
+++ b/copy-to.js
@@ -92,6 +92,7 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
         pushBufferIfneeded();
         this._detach()
         this.push(null)
+        this.destroy()
         return cb();
         break;
       default:


### PR DESCRIPTION
If you use an async iterator to read the stream, it hangs forever after the last row.  Calling `destroy()` to finalise the stream causes the async iterator to realise it has reached the end of the data and exit the loop.