### PR TITLE
Add prettier and reformat code

### DIFF
--- a/bench/copy-from-memory.js
+++ b/bench/copy-from-memory.js
@@ -1,44 +1,51 @@
-var cp = require('duplex-child-process');
+var cp = require('duplex-child-process')
 var pg = require('pg')
 
 var copy = require('../').from
 
-var client = function() {
+var client = function () {
   var client = new pg.Client()
   client.connect()
   return client
 }
 
-var inStream = function() {
-  return cp.spawn('seq', ['0', '29999999']);
+var inStream = function () {
+  return cp.spawn('seq', ['0', '29999999'])
 }
 
-var running = true;
+var running = true
 
-var c = client();
-c.query('DROP TABLE IF EXISTS plugnumber', function() {
-  c.query('CREATE TABLE plugnumber (num int)', function() {
+var c = client()
+c.query('DROP TABLE IF EXISTS plugnumber', function () {
+  c.query('CREATE TABLE plugnumber (num int)', function () {
     var seq = inStream()
     var from = c.query(copy('COPY plugnumber FROM STDIN'))
-    seq.pipe(from);
-    from.on('end', function() {
-      running = false;
-      c.end();
+    seq.pipe(from)
+    from.on('end', function () {
+      running = false
+      c.end()
     })
   })
-})  
-
+})
 
 var rssMin = process.memoryUsage().rss / 1024 / 1024
 var rssMax = rssMin
 
-memlog = function() {
+memlog = function () {
   var rss = process.memoryUsage().rss / 1024 / 1024
   rssMin = Math.min(rss, rssMin)
   rssMax = Math.max(rss, rssMax)
-  console.log('rss:' + Math.round(rss*100)/100 + 'MB rssMin:'+ Math.round(rssMin*100)/100 + 'MB rssMax:' + Math.round(rssMax*100)/100 + 'MB')
+  console.log(
+    'rss:' +
+      Math.round(rss * 100) / 100 +
+      'MB rssMin:' +
+      Math.round(rssMin * 100) / 100 +
+      'MB rssMax:' +
+      Math.round(rssMax * 100) / 100 +
+      'MB'
+  )
   if (running) {
-    setTimeout(memlog, 1000);
+    setTimeout(memlog, 1000)
   }
 }
 

--- a/bench/copy-from.js
+++ b/bench/copy-from.js
@@ -1,86 +1,87 @@
-var Benchmark = require('benchmark');
-var cp = require('duplex-child-process');
+var Benchmark = require('benchmark')
+var cp = require('duplex-child-process')
 var pg = require('pg')
 
 var copy = require('../').from
 
-var client = function() {
+var client = function () {
   var client = new pg.Client()
   client.connect()
   return client
 }
 
 var psql = '/opt/postgresql-9.6.1/bin/psql'
-var limit = 999999;
-var inStream = function() {
-  return cp.spawn('seq', ['0', ''+limit]);
+var limit = 999999
+var inStream = function () {
+  return cp.spawn('seq', ['0', '' + limit])
 }
-var suite = new Benchmark.Suite;
+var suite = new Benchmark.Suite()
 suite
-.add({
-  name: 'unix pipe into psql COPY',
-  defer: true,
-  fn: function(d) {
-    var c = client();
-    c.query('DROP TABLE IF EXISTS plugnumber', function() {
-      c.query('CREATE TABLE plugnumber (num int)', function() {
-        c.end();
-        var from = cp.spawn('sh', ['-c', 'seq 0 '+limit+' | '+psql+' postgres -c \'COPY plugnumber FROM STDIN\''])
-        from.on('close', function() {
-          d.resolve();
+  .add({
+    name: 'unix pipe into psql COPY',
+    defer: true,
+    fn: function (d) {
+      var c = client()
+      c.query('DROP TABLE IF EXISTS plugnumber', function () {
+        c.query('CREATE TABLE plugnumber (num int)', function () {
+          c.end()
+          var from = cp.spawn('sh', [
+            '-c',
+            'seq 0 ' + limit + ' | ' + psql + " postgres -c 'COPY plugnumber FROM STDIN'",
+          ])
+          from.on('close', function () {
+            d.resolve()
+          })
         })
       })
-    })
-  }
-})
-.add({
-  name: 'pipe into psql COPY',
-  defer: true,
-  fn: function(d) {
-    var c = client();
-    c.query('DROP TABLE IF EXISTS plugnumber', function() {
-      c.query('CREATE TABLE plugnumber (num int)', function() {
-        c.end();
-        var seq = inStream();
-        var from = cp.spawn(psql, ['postgres', '-c', 'COPY plugnumber FROM STDIN'])
-        seq.pipe(from);
-        from.on('close', function() {
-          d.resolve();
+    },
+  })
+  .add({
+    name: 'pipe into psql COPY',
+    defer: true,
+    fn: function (d) {
+      var c = client()
+      c.query('DROP TABLE IF EXISTS plugnumber', function () {
+        c.query('CREATE TABLE plugnumber (num int)', function () {
+          c.end()
+          var seq = inStream()
+          var from = cp.spawn(psql, ['postgres', '-c', 'COPY plugnumber FROM STDIN'])
+          seq.pipe(from)
+          from.on('close', function () {
+            d.resolve()
+          })
         })
       })
-    })
-  }
-})
-.add({
-  name: 'pipe into pg-copy-stream COPY',
-  defer: true,
-  fn: function(d) {
-    var c = client();
-    c.query('DROP TABLE IF EXISTS plugnumber', function() {
-      c.query('CREATE TABLE plugnumber (num int)', function() {
-        var seq = inStream()
-        var from = c.query(copy('COPY plugnumber FROM STDIN'))
-        seq.pipe(from);
-        from.on('end', function() {
-          c.end();
-          d.resolve();
+    },
+  })
+  .add({
+    name: 'pipe into pg-copy-stream COPY',
+    defer: true,
+    fn: function (d) {
+      var c = client()
+      c.query('DROP TABLE IF EXISTS plugnumber', function () {
+        c.query('CREATE TABLE plugnumber (num int)', function () {
+          var seq = inStream()
+          var from = c.query(copy('COPY plugnumber FROM STDIN'))
+          seq.pipe(from)
+          from.on('end', function () {
+            c.end()
+            d.resolve()
+          })
         })
       })
-    })
-  }
-})
+    },
+  })
 
-.on('cycle', function(event) {
-  console.log(String(event.target));
-})
-.on('complete', function() {
-  console.log('Fastest is ' + this.filter('fastest').map('name'));
-});
-
+  .on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  .on('complete', function () {
+    console.log('Fastest is ' + this.filter('fastest').map('name'))
+  })
 
 var c = client()
-c.query('DROP TABLE IF EXISTS plugnumber', function() {
-  c.end();
-  suite.run();
+c.query('DROP TABLE IF EXISTS plugnumber', function () {
+  c.end()
+  suite.run()
 })
-

--- a/copy-to.js
+++ b/copy-to.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-module.exports = function(txt, options) {
+module.exports = function (txt, options) {
   return new CopyStreamQuery(txt, options)
 }
 
@@ -8,7 +8,7 @@ var Transform = require('stream').Transform
 var util = require('util')
 var code = require('./message-formats')
 
-var CopyStreamQuery = function(text, options) {
+var CopyStreamQuery = function (text, options) {
   Transform.call(this, options)
   this.text = text
   this._gotCopyOutResponse = false
@@ -19,14 +19,14 @@ util.inherits(CopyStreamQuery, Transform)
 
 var eventTypes = ['close', 'data', 'end', 'error']
 
-CopyStreamQuery.prototype.submit = function(connection) {
+CopyStreamQuery.prototype.submit = function (connection) {
   connection.query(this.text)
   this.connection = connection
   this.connection.removeAllListeners('copyData')
   connection.stream.pipe(this)
 }
 
-CopyStreamQuery.prototype._detach = function() {
+CopyStreamQuery.prototype._detach = function () {
   var connectionStream = this.connection.stream
   connectionStream.unpipe(this)
 
@@ -38,35 +38,34 @@ CopyStreamQuery.prototype._detach = function() {
   })
 }
 
-CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
+CopyStreamQuery.prototype._transform = function (chunk, enc, cb) {
   var offset = 0
-  var Byte1Len = 1;
-  var Int32Len = 4;
-  if(this._remainder && chunk) {
+  var Byte1Len = 1
+  var Int32Len = 4
+  if (this._remainder && chunk) {
     chunk = Buffer.concat([this._remainder, chunk])
   }
 
-  var length;
-  var messageCode;
-  var needPush = false;
+  var length
+  var messageCode
+  var needPush = false
 
-  var buffer = Buffer.alloc(chunk.length);
-  var buffer_offset = 0;
+  var buffer = Buffer.alloc(chunk.length)
+  var buffer_offset = 0
 
-  var self = this;
-  var pushBufferIfneeded = function() {
+  var self = this
+  var pushBufferIfneeded = function () {
     if (needPush && buffer_offset > 0) {
       self.push(buffer.slice(0, buffer_offset))
-      buffer_offset = 0;
+      buffer_offset = 0
     }
   }
 
-  while((chunk.length - offset) >= (Byte1Len + Int32Len)) {
+  while (chunk.length - offset >= Byte1Len + Int32Len) {
     var messageCode = chunk[offset]
 
     //console.log('PostgreSQL message ' + String.fromCharCode(messageCode))
-    switch(messageCode) {
-
+    switch (messageCode) {
       // detect COPY start
       case code.CopyOutResponse:
         if (!this._gotCopyOutResponse) {
@@ -74,49 +73,49 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
         } else {
           this.emit('error', new Error('Unexpected CopyOutResponse message (H)'))
         }
-        break;
+        break
 
       // meaningful row
       case code.CopyData:
-        needPush = true;
-        break;
+        needPush = true
+        break
 
       // standard interspersed messages. discard
       case code.ParameterStatus:
       case code.NoticeResponse:
       case code.NotificationResponse:
-        break;
+        break
 
       case code.ErrorResponse:
       case code.CopyDone:
-        pushBufferIfneeded();
+        pushBufferIfneeded()
         this._detach()
         this.push(null)
-        return cb();
-        break;
+        return cb()
+        break
       default:
         this.emit('error', new Error('Unexpected PostgreSQL message ' + String.fromCharCode(messageCode)))
     }
 
-    length = chunk.readUInt32BE(offset+Byte1Len)
-    if(chunk.length >= (offset + Byte1Len + length)) {
+    length = chunk.readUInt32BE(offset + Byte1Len)
+    if (chunk.length >= offset + Byte1Len + length) {
       offset += Byte1Len + Int32Len
       if (needPush) {
         var row = chunk.slice(offset, offset + length - Int32Len)
         this.rowCount++
-        row.copy(buffer, buffer_offset);
-        buffer_offset += row.length;
+        row.copy(buffer, buffer_offset)
+        buffer_offset += row.length
       }
-      offset += (length - Int32Len)
+      offset += length - Int32Len
     } else {
       // we need more chunks for a complete message
-      break;
+      break
     }
   }
 
-  pushBufferIfneeded();
+  pushBufferIfneeded()
 
-  if(chunk.length - offset) {
+  if (chunk.length - offset) {
     var slice = chunk.slice(offset)
     this._remainder = slice
   } else {
@@ -125,15 +124,12 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
   cb()
 }
 
-CopyStreamQuery.prototype.handleError = function(e) {
+CopyStreamQuery.prototype.handleError = function (e) {
   this.emit('error', e)
 }
 
-CopyStreamQuery.prototype.handleCopyData = function(chunk) {
-}
+CopyStreamQuery.prototype.handleCopyData = function (chunk) {}
 
-CopyStreamQuery.prototype.handleCommandComplete = function() {
-}
+CopyStreamQuery.prototype.handleCommandComplete = function () {}
 
-CopyStreamQuery.prototype.handleReadyForQuery = function() {
-}
+CopyStreamQuery.prototype.handleReadyForQuery = function () {}

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
 var CopyToQueryStream = require('./copy-to')
 module.exports = {
-  to: function(txt, options) {
+  to: function (txt, options) {
     return new CopyToQueryStream(txt, options)
   },
   from: function (txt, options) {
     return new CopyStreamQuery(txt, options)
-  }
+  },
 }
 
 var Transform = require('stream').Transform
 var util = require('util')
 var code = require('./message-formats')
 
-var CopyStreamQuery = function(text, options) {
+var CopyStreamQuery = function (text, options) {
   Transform.call(this, options)
   this.text = text
   this._listeners = null
@@ -24,14 +24,13 @@ var CopyStreamQuery = function(text, options) {
 
 util.inherits(CopyStreamQuery, Transform)
 
-CopyStreamQuery.prototype.submit = function(connection) {
+CopyStreamQuery.prototype.submit = function (connection) {
   this.connection = connection
   connection.query(this.text)
 }
 
-
-CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
-  var Int32Len = 4;
+CopyStreamQuery.prototype._transform = function (chunk, enc, cb) {
+  var Int32Len = 4
   var lenBuffer = Buffer.from([code.CopyData, 0, 0, 0, 0])
   lenBuffer.writeUInt32BE(chunk.length + Int32Len, 1)
   this.push(lenBuffer)
@@ -39,22 +38,22 @@ CopyStreamQuery.prototype._transform = function(chunk, enc, cb) {
   cb()
 }
 
-CopyStreamQuery.prototype._flush = function(cb) {
-  var Int32Len = 4;
+CopyStreamQuery.prototype._flush = function (cb) {
+  var Int32Len = 4
   var finBuffer = Buffer.from([code.CopyDone, 0, 0, 0, Int32Len])
   this.push(finBuffer)
   this.cb_flush = cb
 }
 
-CopyStreamQuery.prototype.handleError = function(e) {
+CopyStreamQuery.prototype.handleError = function (e) {
   this.emit('error', e)
 }
 
-CopyStreamQuery.prototype.handleCopyInResponse = function(connection) {
+CopyStreamQuery.prototype.handleCopyInResponse = function (connection) {
   this.pipe(connection.stream, { end: false })
 }
 
-CopyStreamQuery.prototype.handleCommandComplete = function(msg) {
+CopyStreamQuery.prototype.handleCommandComplete = function (msg) {
   // Parse affected row count as in
   // https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L37
   var match = /COPY (\d+)/.exec((msg || {}).text)
@@ -71,5 +70,4 @@ CopyStreamQuery.prototype.handleCommandComplete = function(msg) {
   this.connection = null
 }
 
-CopyStreamQuery.prototype.handleReadyForQuery = function() {
-}
+CopyStreamQuery.prototype.handleReadyForQuery = function () {}

--- a/message-formats.js
+++ b/message-formats.js
@@ -2,24 +2,24 @@
  * The COPY feature uses the following protocol codes.
  * The codes for the most recent protocol version are documented on
  * https://www.postgresql.org/docs/current/static/protocol-message-formats.html
- * 
+ *
  * The protocol flow itself is described on
  * https://www.postgresql.org/docs/current/static/protocol-flow.html
  */
 module.exports = {
-  ErrorResponse:        0x45, // E
-  CopyInResponse:       0x47, // G
-  CopyOutResponse:      0x48, // H
-  CopyBothResponse:     0x57, // W
-  CopyDone:             0x63, // c
-  CopyData:             0x64, // d
-  CopyFail:             0x66, // f
+  ErrorResponse: 0x45, // E
+  CopyInResponse: 0x47, // G
+  CopyOutResponse: 0x48, // H
+  CopyBothResponse: 0x57, // W
+  CopyDone: 0x63, // c
+  CopyData: 0x64, // d
+  CopyFail: 0x66, // f
 
   // It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages;
   // frontends must handle these cases, and should be prepared for other asynchronous message types as well
   // (see Section 50.2.6).
   // Otherwise, any message type other than CopyData or CopyDone may be treated as terminating copy-out mode.
   NotificationResponse: 0x41, // A
-  NoticeResponse:       0x4E, // N
-  ParameterStatus:      0x53  // S
-} 
+  NoticeResponse: 0x4e, // N
+  ParameterStatus: 0x53, // S
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-copy-streams",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -177,6 +177,12 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
     },
     "semver": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
     "gonna": "0.0.0",
     "heroku-env": "~0.1.1",
     "lodash": "^4.17.11",
-    "pg": "^7.8.2"
+    "pg": "^7.8.2",
+    "prettier": "^2.0.5"
+  },
+  "prettier": {
+    "semi": false,
+    "printWidth": 120,
+    "arrowParens": "always",
+    "trailingComma": "es5",
+    "singleQuote": true
   }
 }

--- a/test/binary.js
+++ b/test/binary.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 var assert = require('assert')
 var gonna = require('gonna')
@@ -11,8 +11,8 @@ var pg = require('pg')
 var from = require('../').from
 var to = require('../').to
 
-var testBinaryCopy = function() {
-  var client = function() {
+var testBinaryCopy = function () {
+  var client = function () {
     var client = new pg.Client()
     client.connect()
     return client
@@ -24,27 +24,27 @@ var testBinaryCopy = function() {
   var queries = [
     'DROP TABLE IF EXISTS data',
     'CREATE TABLE IF NOT EXISTS data (num BIGINT, word TEXT)',
-    'INSERT INTO data (num, word) VALUES (1, \'hello\'), (2, \'other thing\'), (3, \'goodbye\')',
+    "INSERT INTO data (num, word) VALUES (1, 'hello'), (2, 'other thing'), (3, 'goodbye')",
     'DROP TABLE IF EXISTS data_copy',
-    'CREATE TABLE IF NOT EXISTS data_copy (LIKE data INCLUDING ALL)'
+    'CREATE TABLE IF NOT EXISTS data_copy (LIKE data INCLUDING ALL)',
   ]
 
-  async.eachSeries(queries, _.bind(fromClient.query, fromClient), function(err) {
+  async.eachSeries(queries, _.bind(fromClient.query, fromClient), function (err) {
     assert.ifError(err)
 
     var fromStream = fromClient.query(to('COPY (SELECT * FROM data) TO STDOUT BINARY'))
     var toStream = toClient.query(from('COPY data_copy FROM STDIN BINARY'))
 
-    var runStream = function(callback) {
+    var runStream = function (callback) {
       fromStream.on('error', callback)
       toStream.on('error', callback)
       toStream.on('finish', callback)
       fromStream.pipe(toStream)
     }
-    runStream(function(err) {
+    runStream(function (err) {
       assert.ifError(err)
 
-      toClient.query('SELECT * FROM data_copy ORDER BY num', function(err, res){
+      toClient.query('SELECT * FROM data_copy ORDER BY num', function (err, res) {
         assert.equal(res.rowCount, 3, 'expected 3 rows but got ' + res.rowCount)
         assert.equal(res.rows[0].num, 1)
         assert.equal(res.rows[0].word, 'hello')
@@ -52,11 +52,8 @@ var testBinaryCopy = function() {
         assert.equal(res.rows[1].word, 'other thing')
         assert.equal(res.rows[2].num, 3)
         assert.equal(res.rows[2].word, 'goodbye')
-        queries = [
-          'DROP TABLE data',
-          'DROP TABLE data_copy'
-        ]
-        async.each(queries, _.bind(fromClient.query, fromClient), function(err) {
+        queries = ['DROP TABLE data', 'DROP TABLE data_copy']
+        async.each(queries, _.bind(fromClient.query, fromClient), function (err) {
           assert.ifError(err)
           fromClient.end()
           toClient.end()

--- a/test/copy-from.js
+++ b/test/copy-from.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 var assert = require('assert')
 var gonna = require('gonna')
@@ -9,13 +9,13 @@ var pg = require('pg')
 
 var copy = require('../').from
 
-var client = function() {
+var client = function () {
   var client = new pg.Client()
   client.connect()
   return client
 }
 
-var testStreamUnpipe = function() {
+var testStreamUnpipe = function () {
   var fromClient = client()
   fromClient.query('CREATE TEMP TABLE numbers(num int)')
 
@@ -36,10 +36,10 @@ var testStreamUnpipe = function() {
 
 testStreamUnpipe()
 
-var testConstruction = function() {
+var testConstruction = function () {
   var highWaterMark = 10
-  var stream = copy('COPY numbers FROM STDIN', {highWaterMark: 10, objectMode: true})
-  for(var i = 0; i < highWaterMark * 1.5; i++) {
+  var stream = copy('COPY numbers FROM STDIN', { highWaterMark: 10, objectMode: true })
+  for (var i = 0; i < highWaterMark * 1.5; i++) {
     stream.write('1\t2\n')
   }
   assert(!stream.write('1\t2\n'), 'Should correctly set highWaterMark.')
@@ -47,19 +47,19 @@ var testConstruction = function() {
 
 testConstruction()
 
-var testRange = function(top) {
+var testRange = function (top) {
   var fromClient = client()
   fromClient.query('CREATE TEMP TABLE numbers(num int, bigger_num int)')
 
   var txt = 'COPY numbers FROM STDIN'
   var stream = fromClient.query(copy(txt))
-  for(var i = 0; i < top; i++) {
-    stream.write(Buffer.from('' + i + '\t' + i*10 + '\n'))
+  for (var i = 0; i < top; i++) {
+    stream.write(Buffer.from('' + i + '\t' + i * 10 + '\n'))
   }
   stream.end()
   var countDone = gonna('have correct count')
-  stream.on('end', function() {
-    fromClient.query('SELECT COUNT(*) FROM numbers', function(err, res) {
+  stream.on('end', function () {
+    fromClient.query('SELECT COUNT(*) FROM numbers', function (err, res) {
       assert.ifError(err)
       assert.equal(res.rows[0].count, top, 'expected ' + top + ' rows but got ' + res.rows[0].count)
       assert.equal(stream.rowCount, top, 'expected ' + top + ' rows but db count is ' + stream.rowCount)
@@ -67,9 +67,9 @@ var testRange = function(top) {
       countDone()
       var firstRowDone = gonna('have correct result')
       assert.equal(stream.rowCount, top, 'should have rowCount ' + top + ' ')
-      fromClient.query('SELECT (max(num)) AS num FROM numbers', function(err, res) {
+      fromClient.query('SELECT (max(num)) AS num FROM numbers', function (err, res) {
         assert.ifError(err)
-        assert.equal(res.rows[0].num, top-1)
+        assert.equal(res.rows[0].num, top - 1)
         firstRowDone()
         fromClient.end()
       })
@@ -79,47 +79,45 @@ var testRange = function(top) {
 
 testRange(1000)
 
-var testSingleEnd = function() {
+var testSingleEnd = function () {
   var fromClient = client()
   fromClient.query('CREATE TEMP TABLE numbers(num int)')
-  var txt = 'COPY numbers FROM STDIN';
+  var txt = 'COPY numbers FROM STDIN'
   var stream = fromClient.query(copy(txt))
-  var count = 0;
-  stream.on('end', function() {
-    count++;
-    assert(count==1, '`end` Event was triggered ' + count + ' times');
-    if (count == 1) fromClient.end();
+  var count = 0
+  stream.on('end', function () {
+    count++
+    assert(count == 1, '`end` Event was triggered ' + count + ' times')
+    if (count == 1) fromClient.end()
   })
   stream.end(Buffer.from('1\n'))
-    
 }
 testSingleEnd()
 
-var testClientReuse = function() {
+var testClientReuse = function () {
   var fromClient = client()
   fromClient.query('CREATE TEMP TABLE numbers(num int)')
-  var txt = 'COPY numbers FROM STDIN';
-  var count = 0;
-  var countMax = 2;
-  var card = 100000;
-  var runStream = function() {
+  var txt = 'COPY numbers FROM STDIN'
+  var count = 0
+  var countMax = 2
+  var card = 100000
+  var runStream = function () {
     var stream = fromClient.query(copy(txt))
-    stream.on('end', function() {
-      count++;
-      if (count<countMax) {
+    stream.on('end', function () {
+      count++
+      if (count < countMax) {
         runStream()
       } else {
-        fromClient.query('SELECT sum(num) AS s FROM numbers', function(err, res) {
-          var total = countMax * card * (card+1)
+        fromClient.query('SELECT sum(num) AS s FROM numbers', function (err, res) {
+          var total = countMax * card * (card + 1)
           assert.equal(res.rows[0].s, total, 'copy-from.ClientReuse wrong total')
           fromClient.end()
         })
       }
     })
-    stream.write(Buffer.from(_.range(0, card+1).join('\n') + '\n'))
-    stream.end(Buffer.from(_.range(0, card+1).join('\n') + '\n'))
+    stream.write(Buffer.from(_.range(0, card + 1).join('\n') + '\n'))
+    stream.end(Buffer.from(_.range(0, card + 1).join('\n') + '\n'))
   }
-  runStream();
+  runStream()
 }
 testClientReuse()
-

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 var assert = require('assert')
 var gonna = require('gonna')
@@ -6,157 +6,164 @@ var gonna = require('gonna')
 var _ = require('lodash')
 var async = require('async')
 var concat = require('concat-stream')
-var Writable = require('stream').Writable;
+var Writable = require('stream').Writable
 var pg = require('pg')
 
 var copy = require('../').to
 var code = require('../message-formats')
 
-var client = function() {
+var client = function () {
   var client = new pg.Client()
   client.connect()
   return client
 }
 
-var testConstruction = function() {
+var testConstruction = function () {
   var txt = 'COPY (SELECT * FROM generate_series(0, 10)) TO STDOUT'
-  var stream = copy(txt, {highWaterMark: 10})
+  var stream = copy(txt, { highWaterMark: 10 })
   assert.equal(stream._readableState.highWaterMark, 10, 'Client should have been set with a correct highWaterMark.')
 }
 testConstruction()
 
-var testComparators = function() {
-  var copy1 = copy();
-  copy1.pipe(concat(function(buf) {
-    assert(copy1._gotCopyOutResponse, 'should have received CopyOutResponse')
-    assert(!copy1._remainder, 'Message with no additional data (len=Int4Len+0) should not leave a remainder')
-  }))
-  copy1.end(new Buffer.from([code.CopyOutResponse, 0x00, 0x00, 0x00, 0x04])); 
-
-
+var testComparators = function () {
+  var copy1 = copy()
+  copy1.pipe(
+    concat(function (buf) {
+      assert(copy1._gotCopyOutResponse, 'should have received CopyOutResponse')
+      assert(!copy1._remainder, 'Message with no additional data (len=Int4Len+0) should not leave a remainder')
+    })
+  )
+  copy1.end(new Buffer.from([code.CopyOutResponse, 0x00, 0x00, 0x00, 0x04]))
 }
-testComparators();
+testComparators()
 
-var testRange = function(top) {
+var testRange = function (top) {
   var fromClient = client()
   var txt = 'COPY (SELECT * from generate_series(0, ' + (top - 1) + ')) TO STDOUT'
-  var res;
-
+  var res
 
   var stream = fromClient.query(copy(txt))
-  var done = gonna('finish piping out', 1000, function() {
+  var done = gonna('finish piping out', 1000, function () {
     fromClient.end()
   })
 
-  stream.pipe(concat(function(buf) {
-    res = buf.toString('utf8')
-  }))
+  stream.pipe(
+    concat(function (buf) {
+      res = buf.toString('utf8')
+    })
+  )
 
-  stream.on('end', function() {
+  stream.on('end', function () {
     var expected = _.range(0, top).join('\n') + '\n'
     assert.equal(res, expected)
     assert.equal(stream.rowCount, top, 'should have rowCount ' + top + ' but got ' + stream.rowCount)
     done()
-  });
+  })
 }
 testRange(10000)
 
-var testInternalPostgresError = function() {
+var testInternalPostgresError = function () {
   var cancelClient = client()
   var queryClient = client()
 
-  var runStream = function(callback) {
-    var txt = "COPY (SELECT pg_sleep(10)) TO STDOUT"
+  var runStream = function (callback) {
+    var txt = 'COPY (SELECT pg_sleep(10)) TO STDOUT'
     var stream = queryClient.query(copy(txt))
-    stream.on('data', function(data) {
+    stream.on('data', function (data) {
       // Just throw away the data.
     })
     stream.on('error', callback)
 
-    setTimeout(function() {
-      var cancelQuery = "SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query ~ 'pg_sleep' AND NOT query ~ 'pg_cancel_backend'"
-      cancelClient.query(cancelQuery, function() { cancelClient.end() })
+    setTimeout(function () {
+      var cancelQuery =
+        "SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query ~ 'pg_sleep' AND NOT query ~ 'pg_cancel_backend'"
+      cancelClient.query(cancelQuery, function () {
+        cancelClient.end()
+      })
     }, 50)
   }
 
-  runStream(function(err) {
+  runStream(function (err) {
     assert.notEqual(err, null)
     var expectedMessage = 'canceling statement due to user request'
-    assert.notEqual(err.toString().indexOf(expectedMessage), -1, 'Error message should mention reason for query failure.')
+    assert.notEqual(
+      err.toString().indexOf(expectedMessage),
+      -1,
+      'Error message should mention reason for query failure.'
+    )
     queryClient.end()
   })
 }
 testInternalPostgresError()
 
-var testNoticeResponse = function() {
+var testNoticeResponse = function () {
   // we use a special trick to generate a warning
   // on the copy stream.
   var queryClient = client()
-  var set = '';
+  var set = ''
   set += 'SET SESSION client_min_messages = WARNING;'
   set += 'SET SESSION standard_conforming_strings = off;'
   set += 'SET SESSION escape_string_warning = on;'
-  queryClient.query(set, function(err, res) {
+  queryClient.query(set, function (err, res) {
     assert.equal(err, null, 'testNoticeResponse - could not SET parameters')
-    var runStream = function(callback) {
+    var runStream = function (callback) {
       var txt = "COPY (SELECT '\\\n') TO STDOUT"
       var stream = queryClient.query(copy(txt))
-      stream.on('data', function(data) {
-      })
+      stream.on('data', function (data) {})
       stream.on('error', callback)
-     
-      // make sure stream is pulled from 
-      stream.pipe(concat(callback.bind(null,null)))
+
+      // make sure stream is pulled from
+      stream.pipe(concat(callback.bind(null, null)))
     }
 
-    runStream(function(err) {
+    runStream(function (err) {
       assert.equal(err, null, err)
       queryClient.end()
     })
-
   })
 }
-testNoticeResponse();
+testNoticeResponse()
 
-var testClientReuse = function() {
-  var c = client();
-  var limit = 100000;
-  var countMax = 10;
-  var countA = countMax;
-  var countB = 0;
-  var runStream = function(num, callback) {
-    var sql = "COPY (SELECT * FROM generate_series(0,"+limit+")) TO STDOUT"
+var testClientReuse = function () {
+  var c = client()
+  var limit = 100000
+  var countMax = 10
+  var countA = countMax
+  var countB = 0
+  var runStream = function (num, callback) {
+    var sql = 'COPY (SELECT * FROM generate_series(0,' + limit + ')) TO STDOUT'
     var stream = c.query(copy(sql))
     stream.on('error', callback)
-    stream.pipe(concat(function(buf) {
-      var res = buf.toString('utf8');
-      var exp = _.range(0, limit+1).join('\n') + '\n'
-      assert.equal(res, exp, 'clientReuse: sent & received buffer should be equal')
-      countB++;
-      callback();
-    }))
+    stream.pipe(
+      concat(function (buf) {
+        var res = buf.toString('utf8')
+        var exp = _.range(0, limit + 1).join('\n') + '\n'
+        assert.equal(res, exp, 'clientReuse: sent & received buffer should be equal')
+        countB++
+        callback()
+      })
+    )
   }
-  
-  var rs = function(err) {
+
+  var rs = function (err) {
     assert.equal(err, null, err)
-    countA--;
+    countA--
     if (countA) {
       runStream(countB, rs)
     } else {
       assert.equal(countB, countMax, 'clientReuse: there should be countMax queries on the same client')
       c.end()
     }
-  };
+  }
 
-  runStream(countB, rs);
-
+  runStream(countB, rs)
 }
-testClientReuse();
+testClientReuse()
 
-var testClientFlowingState = function() {
+var testClientFlowingState = function () {
   var donePiping = gonna('finish piping out')
   var clientQueryable = gonna('client is still queryable after piping has finished')
-  var c = client();
+  var c = client()
 
   // uncomment the code to see pausing and resuming of the connection stream
 
@@ -181,17 +188,17 @@ var testClientFlowingState = function() {
   }
 
   var writable = new Writable({
-    write: function(chunk, encoding, cb) {
+    write: function (chunk, encoding, cb) {
       cb()
-    }
+    },
   })
-  writable.on('finish', function() {
+  writable.on('finish', function () {
     donePiping()
     setTimeout(testConnection, 100) // test if the connection didn't drop flowing state
   })
 
-  var sql = "COPY (SELECT 1) TO STDOUT"
+  var sql = 'COPY (SELECT 1) TO STDOUT'
   var stream = c.query(copy(sql, { highWaterMark: 1 }))
   stream.pipe(writable)
 }
-testClientFlowingState();
+testClientFlowingState()

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 require('./copy-from')
 require('./copy-to')


### PR DESCRIPTION
Add prettier with config identical to main node-postgres module. Reformat all code. This change follows guidelines set here https://github.com/brianc/node-postgres/issues/2172

The eslint config mentioned in the linked issue is targeted for TypeScript and doesn't add anything for non-TS projects. So let's go with prettier only for now and think of adding eslint when migrating to TypeScript in the future.