### PR TITLE
Add more tests for copy-to

### DIFF
--- a/message-formats.js
+++ b/message-formats.js
@@ -14,6 +14,8 @@ module.exports = {
   CopyDone: 0x63, // c
   CopyData: 0x64, // d
   CopyFail: 0x66, // f
+  CommandComplete: 0x43, // C
+  ReadyForQuery: 0x5a, // Z
 
   // It is possible for NoticeResponse and ParameterStatus messages to be interspersed between CopyData messages;
   // frontends must handle these cases, and should be prepared for other asynchronous message types as well

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64-js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
-      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
-      "dev": true
-    },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
@@ -77,16 +71,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bops": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
-      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
-      "dev": true,
-      "requires": {
-        "base64-js": "0.0.2",
-        "to-utf8": "0.0.1"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -111,6 +95,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "buffer-writer": {
@@ -224,12 +214,15 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.1.0.tgz",
-      "integrity": "sha1-hCae/YzGUCdeMi8wnfRIZ7xRxfM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "dev": true,
       "requires": {
-        "bops": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "debug": {
@@ -851,6 +844,17 @@
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -870,6 +874,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true
     },
     "semver": {
@@ -951,6 +961,15 @@
         "es-abstract": "^1.17.5"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -990,10 +1009,16 @@
         "is-number": "^7.0.0"
       }
     },
-    "to-utf8": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
-      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "async": "~0.2.10",
     "benchmark": "^2.1.4",
-    "concat-stream": "~1.1.0",
+    "concat-stream": "^2.0.0",
     "duplex-child-process": "^1.0.0",
     "heroku-env": "~0.1.1",
     "lodash": "^4.17.11",

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -3,7 +3,6 @@
 var assert = require('assert')
 
 var _ = require('lodash')
-var async = require('async')
 var concat = require('concat-stream')
 var Writable = require('stream').Writable
 var pg = require('pg')

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -200,4 +200,15 @@ describe('copy-to', () => {
       done()
     })
   })
+
+  it('one large row emits multiple chunks', (done) => {
+    const fieldSize = 64 * 1024
+    const sql = `COPY (SELECT repeat('-', ${fieldSize})) TO STDOUT`
+    assertCopyToResult(sql, (err, chunks, result, stream) => {
+      assert.ifError(err)
+      assert(chunks.length > 1)
+      assert.equal(result, `${'-'.repeat(fieldSize)}\n`)
+      done()
+    })
+  })
 })

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -190,4 +190,14 @@ describe('copy-to', () => {
     var stream = client.query(copy(sql, { highWaterMark: 1 }))
     stream.pipe(writable)
   })
+
+  it('two small rows are combined into single chunk', (done) => {
+    const sql = 'COPY (SELECT * FROM generate_series(1, 2)) TO STDOUT'
+    assertCopyToResult(sql, (err, chunks, result, stream) => {
+      assert.ifError(err)
+      assert.equal(chunks.length, 1)
+      assert.deepEqual(chunks[0], Buffer.from('1\n2\n'))
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Here are a few more tests to make sure COPY TO works properly. 

Test that:
- small rows are combined into single chunk
- large row emits multiple chunks
- control sequences cut at chunk boundaries work

To make this happen, I had to refactor:
- extract common assert code into functions
- improve variable and test names
- update concat-stream dependency
