### PR TITLE
Implement copy-from as a Writable stream. COPY now ends on 'finish'

### DIFF
--- a/bench/copy-from.js
+++ b/bench/copy-from.js
@@ -64,7 +64,7 @@ suite
           const seq = inStream()
           const from = c.query(copy('COPY plugnumber FROM STDIN'))
           seq.pipe(from)
-          from.on('end', function () {
+          from.on('finish', function () {
             c.end()
             d.resolve()
           })

--- a/copy-from.js
+++ b/copy-from.js
@@ -1,0 +1,108 @@
+'use strict'
+
+module.exports = function (txt, options) {
+  return new CopyStreamQuery(txt, options)
+}
+
+const { Writable } = require('stream')
+const code = require('./message-formats')
+
+class CopyStreamQuery extends Writable {
+  constructor(text, options) {
+    super(options)
+    this.text = text
+    this.rowCount = 0
+    this._gotCopyInResponse = false
+    this.chunks = []
+    this.cb = null
+    this.cork()
+  }
+
+  submit(connection) {
+    this.connection = connection
+    connection.query(this.text)
+  }
+
+  _write(chunk, enc, cb) {
+    this.chunks.push({ chunk: chunk, encoding: enc })
+    if (this._gotCopyInResponse) {
+      return this.flush(cb)
+    }
+    this.cb = cb
+  }
+
+  _writev(chunks, cb) {
+    this.chunks.push(...chunks)
+    if (this._gotCopyInResponse) {
+      return this.flush(cb)
+    }
+    this.cb = cb
+  }
+
+  _final(cb) {
+    this.flush()
+    const Int32Len = 4
+    const finBuffer = Buffer.from([code.CopyDone, 0, 0, 0, Int32Len])
+    this.connection.stream.write(finBuffer)
+    this.connection = null
+    this.cb_flush = cb
+  }
+
+  flush(callback) {
+    let chunk
+    let ok = true
+    while (ok && (chunk = this.chunks.shift())) {
+      ok = this.flushChunk(chunk.chunk)
+    }
+    if (callback) {
+      if (ok) {
+        callback()
+      } else {
+        if (this.chunks.length) {
+          this.connection.stream.once('drain', this.flush.bind(this, callback))
+        } else {
+          this.connection.stream.once('drain', callback)
+        }
+      }
+    }
+  }
+
+  flushChunk(chunk) {
+    const Int32Len = 4
+    const lenBuffer = Buffer.from([code.CopyData, 0, 0, 0, 0])
+    lenBuffer.writeUInt32BE(chunk.length + Int32Len, 1)
+    this.connection.stream.write(lenBuffer)
+    return this.connection.stream.write(chunk)
+  }
+
+  handleError(e) {
+    this.emit('error', e)
+  }
+
+  handleCopyInResponse(connection) {
+    this._gotCopyInResponse = true
+    this.uncork()
+    this.flush()
+    if (this.cb) {
+      const { cb } = this
+      this.cb = null
+      cb()
+    }
+  }
+
+  handleCommandComplete(msg) {
+    // Parse affected row count as in
+    // https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L37
+    const match = /COPY (\d+)/.exec((msg || {}).text)
+    if (match) {
+      this.rowCount = parseInt(match[1], 10)
+    }
+  }
+
+  handleReadyForQuery() {
+    // triggered after ReadyForQuery
+    // we delay the _final callback so that the 'finish' event is
+    // sent only after the postgres connection is ready for a new query
+    this.cb_flush()
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,72 +1,12 @@
 'use strict'
 
 const CopyToQueryStream = require('./copy-to')
+const CopyFromQueryStream = require('./copy-from')
 module.exports = {
   to: function (txt, options) {
     return new CopyToQueryStream(txt, options)
   },
   from: function (txt, options) {
-    return new CopyStreamQuery(txt, options)
+    return new CopyFromQueryStream(txt, options)
   },
-}
-
-const { Transform } = require('stream')
-const code = require('./message-formats')
-
-class CopyStreamQuery extends Transform {
-  constructor(text, options) {
-    super(options)
-    this.text = text
-    this._listeners = null
-    this._copyOutResponse = null
-    this.rowCount = 0
-  }
-
-  submit(connection) {
-    this.connection = connection
-    connection.query(this.text)
-  }
-
-  _transform(chunk, enc, cb) {
-    const Int32Len = 4
-    const lenBuffer = Buffer.from([code.CopyData, 0, 0, 0, 0])
-    lenBuffer.writeUInt32BE(chunk.length + Int32Len, 1)
-    this.push(lenBuffer)
-    this.push(chunk)
-    cb()
-  }
-
-  _flush(cb) {
-    const Int32Len = 4
-    const finBuffer = Buffer.from([code.CopyDone, 0, 0, 0, Int32Len])
-    this.push(finBuffer)
-    this.cb_flush = cb
-  }
-
-  handleError(e) {
-    this.emit('error', e)
-  }
-
-  handleCopyInResponse(connection) {
-    this.pipe(connection.stream, { end: false })
-  }
-
-  handleCommandComplete(msg) {
-    // Parse affected row count as in
-    // https://github.com/brianc/node-postgres/blob/35e5567f86774f808c2a8518dd312b8aa3586693/lib/result.js#L37
-    const match = /COPY (\d+)/.exec((msg || {}).text)
-    if (match) {
-      this.rowCount = parseInt(match[1], 10)
-    }
-
-    // we delay the _flush cb so that the 'end' event is
-    // triggered after CommandComplete
-    this.cb_flush()
-
-    // unpipe from connection
-    this.unpipe(this.connection.stream)
-    this.connection = null
-  }
-
-  handleReadyForQuery() {}
 }


### PR DESCRIPTION
@brianc @pspi 

There is long time outstanding issue regarding our implementation of copy-from as a Transform stream. We could not find a way to retain the 'finish' event and postgres operations were still ongoing when the 'finish' event was triggered.
This led to a specific note on the README instructing people to wait for the 'end' event to make sure that the COPY was finished.
This is far from ideal since it breaks all sorts of things (people habits to wait on 'finish' on a Writable, pipeline-like API detecting the termination of a Writable, ..)

This PR rewrites copy-from.js as a Writable which makes it possible to delay the 'finish' event until after postgres sends the new ReadyForQuery event.

I'll leave this PR open for some days hoping you will find time to review it and tell me what you think.

thanks