### PR TITLE
Refactor copy-to.js as a Readable extension

### DIFF
--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -255,10 +255,10 @@ describe('copy-to', () => {
       describe('successful stream', () => {
         const successfulSql = `COPY (SELECT 1) TO STDOUT`
 
-        it("emits 1 'finish' (writable stream)", (done) => {
+        it("emits 0 'finish' (readable stream)", (done) => {
           assertCopyToResult(successfulSql, (err, chunks, result, stream) => {
             assert.ifError(err)
-            assert.equal(stream.emits['finish'].length, 1)
+            assert.equal(stream.emits['finish'], undefined)
             done()
           })
         })


### PR DESCRIPTION
@pspi, @brianc I took time to rewrite copy-to as a readable (it is probably better to publish all major refactorings all together instead of slowly over many months)

the implementation was largely inspired from https://github.com/feross/multistream

comments and ideas are welcome !