### PR TITLE
Fix field mismatch error message check to work with Postgres 12

### DIFF
--- a/test/copy-from.js
+++ b/test/copy-from.js
@@ -76,9 +76,14 @@ describe('copy-from', () => {
   it('detect error when field mismatch', (done) => {
     assertCopyFromResult('numbers', '(num int)', [Buffer.from('1,2\n')], (err, rows, stream) => {
       assert.notEqual(err, null)
-      const expectedMessage = 'invalid input syntax for integer'
+      const expectedMessage = /invalid input syntax for (type )?integer/
+      // assert.match(
+      //   err.toString(),
+      //   expectedMessage,
+      //   'Error message should mention reason for query failure.'
+      // )
       assert.notEqual(
-        err.toString().indexOf(expectedMessage),
+        err.toString().search(expectedMessage),
         -1,
         'Error message should mention reason for query failure.'
       )


### PR DESCRIPTION
I noticed that Postgres 12 changed its error message and that causes the test to fail.

The commented-out [`assert.match`](https://nodejs.org/api/assert.html#assert_assert_match_string_regexp_message) syntax is experimentally available since node v12.16.

I'm not certain if and [how](https://github.com/travis-ci/travis-ci/issues/954) the travis-ci can be configured to test on multiple versions.