### PR TITLE
Fix #125

### DIFF
--- a/copy-from.js
+++ b/copy-from.js
@@ -139,6 +139,9 @@ class CopyStreamQuery extends Writable {
     // sent only when the ingested data is visible inside postgres and
     // after the postgres connection is ready for a new query
 
+    // Call the `pg` handler to clear the query-timeout timer.
+    if (this.callback) this.callback();
+
     // Note: `pg` currently does not call this callback when the backend
     // sends an ErrorResponse message during the query (for example during
     // a CopyFail)


### PR DESCRIPTION
This is a suggested fix for #125.  It doesn't completely resolve the problem due to a bug in the `pg` module (which calls the callback without first checking whether a callback was supplied, PR https://github.com/brianc/node-postgres/pull/2614) but after fixing that bug in the `pg` module, this clears the timeout and fixes the error.

I also haven't checked whether copyTo has a similar issue, so consider this more of a pointer to a possible solution rather than a concrete solution.