### PR TITLE
chore: update csv-parse from v4 to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "async": "~0.2.10",
         "benchmark": "^2.1.4",
         "concat-stream": "^2.0.0",
-        "csv-parse": "^4.9.0",
+        "csv-parse": "^5.6.0",
         "csv-parser": "^2.3.2",
         "duplex-child-process": "^1.0.0",
         "eslint": "^6.8.0",
@@ -444,10 +444,11 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
-      "dev": true
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csv-parser": {
       "version": "2.3.5",
@@ -2882,9 +2883,9 @@
       }
     },
     "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
       "dev": true
     },
     "csv-parser": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "~0.2.10",
     "benchmark": "^2.1.4",
     "concat-stream": "^2.0.0",
-    "csv-parse": "^4.9.0",
+    "csv-parse": "^5.6.0",
     "csv-parser": "^2.3.2",
     "duplex-child-process": "^1.0.0",
     "eslint": "^6.8.0",

--- a/test/copy-to.js
+++ b/test/copy-to.js
@@ -11,7 +11,7 @@ const { Transform } = require('stream')
 const { promisify } = require('util')
 
 const csvParser = require('csv-parser')
-const csvParse = require('csv-parse')
+const csvParse = require('csv-parse').parse
 
 const copy = require('../').to
 const code = require('../message-formats')


### PR DESCRIPTION
update csv-parse from v4 to v5
- <https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/CHANGELOG.md>
- Confirmed that all tests pass