### PR TITLE
chore: update csv-parse from v5 to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "async": "~0.2.10",
         "benchmark": "^2.1.4",
         "concat-stream": "^2.0.0",
-        "csv-parse": "^5.6.0",
+        "csv-parse": "^6.1.0",
         "csv-parser": "^3.2.0",
         "duplex-child-process": "^1.0.0",
         "eslint": "^9.27.0",
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
-      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "~0.2.10",
     "benchmark": "^2.1.4",
     "concat-stream": "^2.0.0",
-    "csv-parse": "^5.6.0",
+    "csv-parse": "^6.1.0",
     "csv-parser": "^3.2.0",
     "duplex-child-process": "^1.0.0",
     "eslint": "^9.27.0",


### PR DESCRIPTION
update csv-parse from v5 to v6
- <https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/CHANGELOG.md>
-  Confirmed that the test passes